### PR TITLE
create Dockerfile and compose.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:alpine3.21 as node
+
+EXPOSE 5173
+
+WORKDIR /app
+
+COPY . .
+
+RUN yarn
+
+CMD ["yarn", "dev", "--host"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  chirp:
+    build: .
+    ports:
+      - "5173:5173"


### PR DESCRIPTION
Added a Dockerfile and compose.yaml

dockerfile uses node:alpine3.21 as base image, copies the source into /app and runs yarn to build, then runs it with `yarn dev --host` and exposes port 5173. This makes it very easy to build and run quickly without having anything installed on the host system.

can simply be built and run with 
`docker compose up --build`